### PR TITLE
[Fix] merge from config path in ServiceProvider

### DIFF
--- a/src/Providers/StatemachineProvider.php
+++ b/src/Providers/StatemachineProvider.php
@@ -24,10 +24,10 @@ class StatemachineProvider extends ServiceProvider
 
     protected function registerConfigurations()
     {
+        $configPath = __DIR__ . '/../config/state-machine.php';
         $this->publishes([
-            __DIR__ . '/../config/state-machine.php' => config_path('state-machine.php')
+            $configPath => config_path('state-machine.php')
         ], 'config');
-
-        $this->mergeConfigFrom(config_path('state-machine.php'), 'state-machine');
+        $this->mergeConfigFrom($configPath, 'state-machine');
     }
 }


### PR DESCRIPTION
First, thanks for this great state machine package.

This PR fixes a hen egg problem: artisan vendor:publish throwing file not found exception for merge config file

I might be mistaking the purpose of `ServiceProvider::mergeConfigFrom` but I think it expects a path to the *local* (i.e. under the vendor/namespace dir) config file, not the path to the published one. Otherwise it will throw an exception *unless* config/state-machine.php exists already at the project root.

So, the line `$this->mergeConfigFrom(config_path('state-machine.php'), 'state-machine');`
should be `$this->mergeConfigFrom( __DIR__ . '/../config/state-machine.php', 'state-machine'), 'state-machine');`